### PR TITLE
Define OB_ISNAN to handle differences between MSVC versions

### DIFF
--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -21,13 +21,10 @@ GNU General Public License for more details.
 #include <openbabel/math/align.h>
 #include <openbabel/forcefield.h>
 
-#if defined(_MSC_VER)
-#if _MSC_VER < 1800
-namespace std {
-  template <typename T>
-  bool isnan(const T &x) { return _isnan(x); }
-}
-#endif
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
+ #define OB_ISNAN _isnan
+#else
+ #define OB_ISNAN std::isnan
 #endif
 
 namespace OpenBabel {
@@ -629,7 +626,7 @@ namespace OpenBabel {
           // make the selection
           score = MakeSelection();
         }
-      if (std::isnan(score)) {
+      if (OB_ISNAN(score)) {
           (*m_logstream) << "The current score is not a number, will not continue."  << endl  << endl;
           return;
       }


### PR DESCRIPTION
Rather than alter the std namespace, over which we have no control, this solution uses a level of indirection to handle the differences between compilers. Tested in MSVC 2012 (uses _isnan) and MSVC 2013 (uses std::isnan).